### PR TITLE
Add fixtures for orgs, org types and users

### DIFF
--- a/test/fixtures/org/types.yml
+++ b/test/fixtures/org/types.yml
@@ -1,3 +1,7 @@
 group:
-  name: 'group'
-  icon_url: 'org_types/group.png'
+  name: group
+  icon_url: orgs/types/group.png
+
+association:
+  name: association
+  icon_url: orgs/types/association.png

--- a/test/fixtures/orgs.yml
+++ b/test/fixtures/orgs.yml
@@ -1,0 +1,21 @@
+org1:
+  id: testorg1
+  display_id: TestOrg1
+  type: group
+  name: Test Organization 1
+  logo_url: orgs/logos/testorg1.png
+  cover_url: orgs/covers/testorg1.jpg
+  video_url: orgs/videos/testorg1.mp4
+  marker_url: orgs/markers/testorg1.png
+  marker_color: "000000"
+
+org2:
+  id: testorg2
+  display_id: TestOrg2
+  type: association
+  name: Test Organization 2
+  logo_url: orgs/logos/testorg2.png
+  cover_url: orgs/covers/testorg2.jpg
+  marker_url: orgs/markers/testorg2.png
+  marker_color: "000000"
+    

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,7 +1,20 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+user1:
+  id: user1
+  email: user1@example.com
+  password_digest: <%= User.password_digest "password1" %>
+  activation_digest: <%= User.password_digest "activation1" %>
+  admin: false
 
-one:
-  password_digest: MyString
+user2:
+  id: user2
+  email: user2@example.com
+  password_digest: <%= User.password_digest "password2" %>
+  activation_digest: null
+  admin: false
 
-two:
-  password_digest: MyString
+user2:
+  id: user3
+  email: user3@example.com
+  password_digest: <%= User.password_digest "password3" %>
+  activation_digest: null
+  admin: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,7 +12,7 @@ user2:
   activation_digest: null
   admin: false
 
-user2:
+user3:
   id: user3
   email: user3@example.com
   password_digest: <%= User.password_digest "password3" %>

--- a/test/models/org/type_test.rb
+++ b/test/models/org/type_test.rb
@@ -10,25 +10,25 @@ class Org::TypeTest < ActiveSupport::TestCase
 
     # Test without name
     t.name = nil
-    t.icon_url = 'org_types/association.png'
+    t.icon_url = 'org_types/testtype.png'
     assert_not t.save
     assert_not_empty t.errors[:name]
 
     # Test without icon url
-    t.name = 'association'
+    t.name = 'testtype'
     t.icon_url = nil
     assert_not t.save
     assert_not_empty t.errors[:icon_url]
 
     # Test with attributes
-    t.name = 'association'
-    t.icon_url = 'org_types/association.png'
+    t.name = 'testtype'
+    t.icon_url = 'org_types/testtype.png'
     assert t.save
   end
 
   test "should enforce name uniqueness" do
-    t1 = Org::Type.new name: 'party', icon_url: 'org_types/party.png'
-    t2 = Org::Type.new name: 'party', icon_url: 'org_types/parties.png'
+    t1 = Org::Type.new name: 'testtype2', icon_url: 'org_types/testtype2.png'
+    t2 = Org::Type.new name: 'testtype2', icon_url: 'org_types/testtype2.png'
     assert t1.save
     assert_not t2.save
     assert_not_empty t2.errors[:name]

--- a/test/models/org_test.rb
+++ b/test/models/org_test.rb
@@ -129,7 +129,7 @@ class OrgTest < ActiveSupport::TestCase
   end
 
   test "should not destroy type if associated with organization" do
-    t = Org::Type.new name: 'association', icon_url: 'org_types/association.png'
+    t = Org::Type.new name: 'undestructable', icon_url: 'org_types/undestructable.png'
     o = Org.new(default_options.merge display_id: 'Typed', name: "Typed", type: t)
     assert t.save
     assert o.save


### PR DESCRIPTION
Add fixtures for organizations, organization types and users and adapt
the organization and organization type tests cases to avoid collisions.