### PR TITLE
Change message attribute in format validations

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -5,7 +5,7 @@ class Org < ApplicationRecord
 
   # Validate organization id length and character restrictions
   validates :id, length: {minimum: 4, maximum: 30}, uniqueness: true,
-    format: { with: /\A[a-z0-9]*\z/, message: :invalid_characters }, presence: true
+    format: { with: /\A[a-z0-9]*\z/, error: :invalid_characters }, presence: true
 
   # Validate name
   validates :name, length: { minimum: 4, maximum: 30 }, uniqueness: true, presence: true
@@ -15,7 +15,7 @@ class Org < ApplicationRecord
 
   # Validate color format
   validates :marker_color, length: { is: 6 },
-    format: { with: /\A[0-9a-f]*\z/, message: :invalid_characters }, presence: true
+    format: { with: /\A[0-9a-f]*\z/, error: :invalid_characters }, presence: true
 
   # Make id only writable via display_id
   private :id=

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
 
   # Validate user id length and character restriction
   validates :id, length: { minimum: 5, maximum: 20 }, uniqueness: true,
-    format: { with: /\A[a-z0-9_]*\z/, message: :invalid_characters}, presence: true
+    format: { with: /\A[a-z0-9_]*\z/, error: :invalid_characters}, presence: true
 
   # Validate valid email address
   validates :email, email_format: true, uniqueness: true, presence: true


### PR DESCRIPTION
Replace "mesage: ..." with "error: ..." to actually set the error name
instead of the string message.