### PR TITLE
Refactor model tests and fix models if necessary

### DIFF
--- a/app/models/org/type.rb
+++ b/app/models/org/type.rb
@@ -2,6 +2,7 @@ class Org::Type < ApplicationRecord
   ################
   # Associations #
   ################
+
   has_many :orgs, foreign_key: :org_type_id, dependent: :restrict_with_error
 
   ###############

--- a/test/models/event/description_test.rb
+++ b/test/models/event/description_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
 class Event::DescriptionTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "should only save with available language" do
     # Test description without language
-    d = new_description language: nil
+    d = new_event_description language: nil
     e = new_event descriptions: [d]
     assert_invalid e
 
@@ -18,7 +20,7 @@ class Event::DescriptionTest < ActiveSupport::TestCase
 
   test "should only save with valid content" do
     # Test without content
-    d = new_description content: nil
+    d = new_event_description content: nil
     e = new_event descriptions: [d]
     assert_invalid e
 
@@ -43,10 +45,10 @@ class Event::DescriptionTest < ActiveSupport::TestCase
     # Create descriptions and events
     l1 = I18n.available_locales[0]
     l2 = I18n.available_locales[1]
-    d1 = new_description language: l1, content: "Test"
-    d2 = new_description language: l1, content: "Test"
-    e1 = new_event
-    e2 = new_event
+    d1 = new_event_description language: l1, content: "Test"
+    d2 = new_event_description language: l1, content: "Test"
+    e1 = new_event descriptions: []
+    e2 = new_event descriptions: []
 
     # Test same language and same event
     e1.descriptions << d1
@@ -61,35 +63,16 @@ class Event::DescriptionTest < ActiveSupport::TestCase
 
   test "should change updated_at timestamp on event model" do
     # Create event and description
-    d = new_description
+    d = new_event_description
     e = new_event descriptions: [d]
 
     # Save event
     assert e.save
 
     # Test updated_at change when changing description
-    updated_before = e.updated_at
-    d.content = "Some other content"
-    d.save
-    assert_not_equal e.updated_at, updated_before
-  end
-
-  # Create event with defaults
-  def new_event params={}
-    Event.new({
-      type: event_types(:demonstration),
-      name: "Test Event",
-      start_time: DateTime.now
-      # Descriptions need to be passed
-    }.merge(params))
-  end
-
-  # Create event description with defaults
-  def new_description params={}
-    Event::Description.new({
-      language: I18n.locale,
-      content: "Dolor veniam cum voluptas ratione nam obcaecati nobis!"
-      # Needs to be assigned to an event
-    }.merge(params))
+    assert_changes 'e.updated_at' do
+      d.content = "Some other content"
+      d.save
+    end
   end
 end

--- a/test/models/event/type_test.rb
+++ b/test/models/event/type_test.rb
@@ -1,16 +1,43 @@
 require 'test_helper'
 
 class Event::TypeTest < ActiveSupport::TestCase
-  test "should not save without both attributes" do
-    # Create without attributes
-    t = Event::Type.new
-    assert_not t.save
-    assert_not_empty t.errors[:name]
-    assert_not_empty t.errors[:icon_url]
+  include ModelInstantiationHelper
 
-    # Set attributes
-    t.name = "temporary"
-    t.icon_url = "icons/temporary"
+  test "should only save with name and icon url" do
+    # Test without attributes
+    t = new_event_type name: nil, icon_url: nil
+    assert_invalid t, name: :blank, icon_url: :blank
+
+    # Test without name
+    t.name = nil
+    t.icon_url = 'event_types/testtype.png'
+    assert_invalid t, name: :blank
+
+    # Test without icon url
+    t.name = 'testtype'
+    t.icon_url = nil
+    assert_invalid t, icon_url: :blank
+
+    # Test with attributes
+    t.name = 'testtype'
+    t.icon_url = 'event_types/testtype.png'
     assert t.save
+  end
+
+  test "should enforce name uniqueness" do
+    t1 = new_event_type name: 'uniquename'
+    t2 = new_event_type name: 'uniquename'
+    assert t1.save
+    assert_invalid t2, name: :taken
+  end
+
+  test "should not destroy if associated with event" do
+    t = new_event_type name: 'indestructable'
+    e = new_event type: t
+    assert t.save
+    assert e.save
+    assert_not t.destroy
+    assert e.destroy
+    assert t.destroy
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,16 +1,24 @@
 require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "should save with and without organization" do
     # Test without org
-    e = new_event
-    e.org = nil
-    assert e.save, "Expected save but failed with #{e.errors.messages}"
+    e = new_event org: nil
+    assert e.save
 
     # Test with org
-    e.org = orgs(:org1)
+    o = new_org
+    o.save
+    e.org = o
     assert e.save
-    assert orgs(:org1).reload.events.include?(e)
+    assert_includes o.reload.events, e
+  end
+
+  test "should not save without type" do
+    e = new_event type: nil
+    assert_invalid e, type: :blank
   end
 
   test "should only save with valid name" do
@@ -23,7 +31,7 @@ class EventTest < ActiveSupport::TestCase
     assert_invalid e, name: :blank
 
     # Test with too short name
-    e.name = "abc"
+    e.name = "Srt"
     assert_invalid e, name: :too_short
 
     # Test with too long name
@@ -39,15 +47,43 @@ class EventTest < ActiveSupport::TestCase
     assert e.save
   end
 
-  test "should not save without type" do
-    e = new_event 
-    e.type = nil
-    assert_invalid e, type: :blank
+  test "should not save with empty image url" do
+    # Test without image url
+    e = new_event image_url: nil
+    assert e.save
+
+    # Test with empty image url
+    e.image_url = ""
+    assert_invalid e, image_url: :blank
+
+    # Test with valid image url
+    e.image_url = "events/images/0.png"
+    assert e.save
+  end
+
+  test "should not save without start time" do
+    e = new_event start_time: nil
+    assert_invalid e, start_time: :blank
+  end
+
+  test "should not save with empty facebook url" do
+    return
+    # Test without facebook url
+    e = new_event fb_url: nil
+    assert e.save
+
+    # Test with empty facebook url
+    e.fb_url = ""
+    assert_invalid e, fb_url: :blank
+
+    # Test with valid facebook url
+    e.fb_url = "/TheAnimalRightsNet/events/tests_event"
+    assert e.save
   end
 
   test "should save and destroy descriptions automatically" do
     # Create event with description
-    d = new_description
+    d = new_event_description
     e = new_event descriptions: [d]
 
     # Test description unsaved before and saved after event save
@@ -64,95 +100,5 @@ class EventTest < ActiveSupport::TestCase
   test "should not save without description" do
     e = new_event descriptions: []
     assert_invalid e, descriptions: :empty
-  end
-
-  test "should not save without start time" do
-    e = new_event start_time: nil
-    assert_invalid e, start_time: :blank
-  end
-
-  test "should not save with empty image url" do
-    e = new_event image_url: nil
-    assert e.save
-    e.image_url = ""
-    assert_invalid e, image_url: :blank
-  end
-
-  test "should only save without or with non empty facebook url" do
-    # Create event
-    e = new_event fb_url: nil
-
-    # Test without facebook url
-    assert e.save
-
-    # Test with empty facebook url
-    e.fb_url = ""
-    assert_invalid e, fb_url: :blank
-
-    # Test with non empty facebook url
-    e.fb_url = "/TheAnimalRightsNet/events/tests_event"
-    assert e.save
-  end
-
-  test "should interact with tags" do
-    # Create event and tag
-    e = new_event
-    t = new_tag
-    assert e.save
-
-    # Test successful tag assignment
-    assert t.new_record?
-    assert e.tags << t
-    assert_not t.new_record?
-    e = Event.find e.id
-    assert e.tags.include?(t)
-
-    # Test successful event removal
-    t = Event::Tag.find t.id
-    t.events.clear
-    assert e.tags.empty?
-  end
-
-  test "should prevent event tag duplicates" do
-    # Create event and tag
-    e = new_event
-    t = new_tag
-
-    # Test adding tag first time
-    e.tags << t
-    assert e.save
-
-    # Test adding tag second time
-    assert_raises ActiveRecord::RecordNotUnique do
-      e.tags << t
-    end
-  end
-
-  # Create event with defaults
-  def new_event params={}
-    Event.new({
-      descriptions: [new_description],
-      type: event_types(:demonstration),
-      name: "Test Event",
-      start_time: DateTime.now
-    }.merge(params))
-  end
-
-  # Create event description with defaults
-  def new_description params={}
-    Event::Description.new({
-      language: I18n.locale,
-      content: "Dolor veniam cum voluptas ratione nam obcaecati nobis!"
-      # Needs to be assigned to an event
-    }.merge(params))
-  end
-
-  # Create event tag with defaults
-  def new_tag params={}
-    Event::Tag.new({
-      name: 'testtag',
-      icon_url: "events/tags/graphic.png",
-      color: 'ff8000'
-    }.merge(params))
   end
 end

--- a/test/models/link_type_test.rb
+++ b/test/models/link_type_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class LinkTypeTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "should only save if name is present" do
     # Test without name
     t = new_link_type name: nil
@@ -11,7 +13,7 @@ class LinkTypeTest < ActiveSupport::TestCase
     assert_invalid t, name: :blank
 
     # Test with valid name
-    t.name = 'testtype'
+    t.name = "testtype"
     assert t.save
   end
 
@@ -34,13 +36,5 @@ class LinkTypeTest < ActiveSupport::TestCase
     # Test with valid icon url
     t.icon_url = "link_types/testtype.png"
     assert t.save
-  end
-
-  # Create link type with defaults
-  def new_link_type params={}
-    LinkType.new({
-      name: 'testtype',
-      icon_url: "link_types/testtype.png",
-    }.merge(params))
   end
 end

--- a/test/models/org/description_test.rb
+++ b/test/models/org/description_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
 class Org::DescriptionTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "should only save with available language" do
     # Test description without language
-    d = new_description language: nil
+    d = new_org_description language: nil
     o = new_org descriptions: [d]
     assert_invalid o
 
@@ -18,7 +20,7 @@ class Org::DescriptionTest < ActiveSupport::TestCase
 
   test "should only save with valid content" do
     # Test without content
-    d = new_description content: nil
+    d = new_org_description content: nil
     o = new_org descriptions: [d]
     assert_invalid o
 
@@ -43,10 +45,10 @@ class Org::DescriptionTest < ActiveSupport::TestCase
     # Create descriptions and organizations
     l1 = I18n.available_locales[0]
     l2 = I18n.available_locales[1]
-    d1 = new_description language: l1, content: "Test"
-    d2 = new_description language: l1, content: "Test"
-    o1 = new_org display_id: "Org1", name: "Organization 1"
-    o2 = new_org display_id: "Org2", name: "Organization 2"
+    d1 = new_org_description language: l1, content: "Test"
+    d2 = new_org_description language: l1, content: "Test"
+    o1 = new_org display_id: "Org1", name: "Organization 1", descriptions: []
+    o2 = new_org display_id: "Org2", name: "Organization 2", descriptions: []
 
     # Test same language and same organization
     o1.descriptions << d1
@@ -61,39 +63,16 @@ class Org::DescriptionTest < ActiveSupport::TestCase
 
   test "should change updated_at timestamp on organization model" do
     # Create organization and description
-    d = new_description
+    d = new_org_description
     o = new_org descriptions: [d]
 
     # Save organization
     assert o.save
 
     # Test updated_at change when changing description
-    updated_before = o.updated_at
-    d.content = "Some other content"
-    d.save
-    assert_not_equal o.updated_at, updated_before
-  end
-
-  # Create organization with defaults
-  def new_org params={}
-    Org.new({
-      display_id: 'TestOrganization',
-      type: Org::Type.find_by(name: :association),
-      name: "Test Organization",
-      logo_url: "orgs/logos/testorg2.png",
-      cover_url: "orgs/covers/testorg2.jpg",
-      marker_url: "orgs/markers/testorg2.png",
-      marker_color: '000000'
-      # Descriptions need to be passed
-    }.merge(params))
-  end
-
-  # Create organization description with defaults
-  def new_description params={}
-    Org::Description.new({
-      language: I18n.locale,
-      content: "Dolor veniam cum voluptas ratione nam obcaecati nobis!"
-      # Needs to be assigned to an organization
-    }.merge(params))
+    assert_changes 'o.updated_at' do
+      d.content = "Some other content"
+      d.save
+    end
   end
 end

--- a/test/models/org/link_test.rb
+++ b/test/models/org/link_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
 class Org::LinkTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "Should only save with url" do
     # Test without url
-    l = new_link url: nil
+    l = new_org_link url: nil, org: new_org
     assert_invalid l, url: :blank
 
     # Test empty url
@@ -17,22 +19,22 @@ class Org::LinkTest < ActiveSupport::TestCase
 
   test "should not save without organization or type" do
     # Test without organization
-    l = new_link org: nil
+    l = new_org_link org: nil
     assert_invalid l, org: :blank
 
     # Test without link type
-    l = new_link link_type: nil
+    l = new_org_link link_type: nil
     assert_invalid l, link_type: :blank
   end
 
   test "should enforce type uniqueness per organization" do
     # Create links, types and organizations
-    t1 = new_type name: 'testtype1'
-    t2 = new_type name: 'testtype2'
+    t1 = new_link_type name: 'testtype1'
+    t2 = new_link_type name: 'testtype2'
     o1 = new_org display_id: "Org1", name: "Organization 1"
     o2 = new_org display_id: "Org2", name: "Organization 2"
-    l1 = new_link link_type: t1, url: "http://test1.com"
-    l2 = new_link link_type: t1, url: "http://test2.com"
+    l1 = new_org_link link_type: t1, url: "http://test1.com"
+    l2 = new_org_link link_type: t1, url: "http://test2.com"
 
     # Test same type and same organization
     o1.links << l1
@@ -43,45 +45,5 @@ class Org::LinkTest < ActiveSupport::TestCase
     # Test different type and same organization
     l2.link_type = t2
     assert o1.save
-  end
-
-  # Create link with defaults
-  def new_link params={}
-    Org::Link.new({
-      org: Org.last,
-      link_type: LinkType.last,
-      url: "https://test.com/"
-    }.merge(params))
-  end
-
-  # Create link type with defaults
-  def new_type params={}
-    LinkType.new({
-      name: 'testtype',
-      icon_url: "link_types/testtype.png",
-    }.merge(params))
-  end
-
-  # Create organization with defaults
-  def new_org params={}
-    Org.new({
-      display_id: "TestOrganization",
-      type: Org::Type.find_by(name: :association),
-      name: "Test Organization",
-      logo_url: "orgs/logos/testorg2.png",
-      cover_url: "orgs/covers/testorg2.jpg",
-      marker_url: "orgs/markers/testorg2.png",
-      marker_color: '000000',
-      descriptions: [new_description]
-    }.merge(params))
-  end
-
-  # Create organization description with defaults
-  def new_description params={}
-    Org::Description.new({
-      language: I18n.locale,
-      content: "Dolor veniam cum voluptas ratione nam obcaecati nobis!"
-      # Needs to be assigned to an organization
-    }.merge(params))
   end
 end

--- a/test/models/org/type_test.rb
+++ b/test/models/org/type_test.rb
@@ -1,24 +1,22 @@
 require 'test_helper'
 
 class Org::TypeTest < ActiveSupport::TestCase
+  include ModelInstantiationHelper
+
   test "should only save with name and icon url" do
     # Test without attributes
-    t = Org::Type.new
-    assert_not t.save
-    assert_not_empty t.errors[:name]
-    assert_not_empty t.errors[:icon_url]
+    t = new_org_type name: nil, icon_url: nil
+    assert_invalid t, name: :blank, icon_url: :blank
 
     # Test without name
     t.name = nil
     t.icon_url = 'org_types/testtype.png'
-    assert_not t.save
-    assert_not_empty t.errors[:name]
+    assert_invalid t, name: :blank
 
     # Test without icon url
     t.name = 'testtype'
     t.icon_url = nil
-    assert_not t.save
-    assert_not_empty t.errors[:icon_url]
+    assert_invalid t, icon_url: :blank
 
     # Test with attributes
     t.name = 'testtype'
@@ -27,10 +25,19 @@ class Org::TypeTest < ActiveSupport::TestCase
   end
 
   test "should enforce name uniqueness" do
-    t1 = Org::Type.new name: 'testtype2', icon_url: 'org_types/testtype2.png'
-    t2 = Org::Type.new name: 'testtype2', icon_url: 'org_types/testtype2.png'
+    t1 = new_org_type name: 'uniquename'
+    t2 = new_org_type name: 'uniquename'
     assert t1.save
-    assert_not t2.save
-    assert_not_empty t2.errors[:name]
+    assert_invalid t2, name: :taken
+  end
+
+  test "should not destroy if associated with org" do
+    t = new_org_type name: 'indestructable'
+    o = new_org type: t
+    assert t.save
+    assert o.save
+    assert_not t.destroy
+    assert o.destroy
+    assert t.destroy
   end
 end

--- a/test/shared/model_instantiation_helper.rb
+++ b/test/shared/model_instantiation_helper.rb
@@ -1,0 +1,105 @@
+# Instantiation shortcuts for each data model
+module ModelInstantiationHelper
+  # Create user with defaults
+  def new_user opts={}
+    User.new({
+      display_id: "TestUser",
+      email: "testuser@example.com",
+      password: "TestPassw0rd",
+      password_confirmation: "TestPassw0rd"
+    }.merge(opts))
+  end
+
+  # Create organization with defaults
+  def new_org opts={}
+    Org.new({
+      display_id: "TestOrg",
+      type: new_org_type,
+      name: "Test Organization",
+      logo_url: "orgs/logos/testorg.png",
+      cover_url: "orgs/covers/testorg.png",
+      marker_url: "orgs/markers/testorg.png",
+      marker_color: "00ff00",
+      descriptions: [new_org_description]
+    }.merge(opts))
+  end
+
+  # Create organization type with defaults
+  def new_org_type opts={}
+    Org::Type.new({
+      name: "testtype",
+      icon_url: "orgs/types/testtype.png"
+    }.merge(opts))
+  end
+
+  # Create organization description with defaults
+  def new_org_description opts={}
+    Org::Description.new({
+      # Needs to get assigned to an organization
+      language: I18n.locale,
+      content: "Amet earum expedita consectetur ducimus id."
+    }.merge(opts))
+  end
+
+  # Create organization tag with defaults
+  def new_org_tag opts={}
+    Org::Tag.new({
+      name: "testtag",
+      icon_url: "orgs/tags/testtag",
+      color: "00ff00"
+    }.merge(opts))
+  end
+
+  # Create organization link with defaults
+  def new_org_link opts={}
+    Org::Link.new({
+      # Needs to get assigned to an organization
+      link_type: new_link_type,
+      url: "https://example.com/"
+    }.merge(opts))
+  end
+
+  # Create link type with defaults
+  def new_link_type opts={}
+    LinkType.new({
+      name: "testtype",
+      icon_url: "link_types/testtype.png"
+    }.merge(opts))
+  end
+
+  # Create event with defaults
+  def new_event opts={}
+    Event.new({
+      type: new_event_type,
+      name: "testevent",
+      start_time: DateTime.now,
+      descriptions: [new_event_description]
+    }.merge(opts))
+  end
+
+  # Create event type with defaults
+  def new_event_type opts={}
+    Event::Type.new({
+      name: "testtype",
+      icon_url: "events/types/testtype.png"
+    }.merge(opts))
+  end
+
+  # Create event description with defaults
+  def new_event_description opts={}
+    Event::Description.new({
+      # Needs to be assigned to an event
+      language: I18n.locale,
+      content: "Sit modi veritatis aspernatur assumenda itaque."
+    }.merge(opts))
+  end
+
+  # Create event tag with defaults
+  def new_event_tag opts={}
+    Event::Tag.new({
+      name: "testtag",
+      icon_url: "events/tags/testtag.png",
+      color: "00ff00"
+    }.merge(opts))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+# Require shared helpers
+Dir[Rails.root.join('test/shared/**/*.rb')].each { |f| require f }
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
Add directory for shared helper methods with a module for model
instantiation shortcuts and requires it in the test helper class.